### PR TITLE
update to 1.20.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 1.17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'adopt'
-        java-version: 17
+        java-version: 21
     - name: Cache Gradle packages
       uses: actions/cache@v4
       with:

--- a/.github/workflows/minepkg-publish.yml
+++ b/.github/workflows/minepkg-publish.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: 17
+          java-version: 21
       - name: Publish package on minepkg.io
         uses: minepkg/action-publish@main
         with:

--- a/.minepkg-lock.toml
+++ b/.minepkg-lock.toml
@@ -4,20 +4,20 @@
 lockfileVersion = 1
 
 [fabric]
-  minecraft = "1.20.2"
+  minecraft = "1.20.6"
   fabricLoader = "0.16.10"
-  mapping = "1.20.2+build.4"
+  mapping = "1.20.6+build.3"
 
 [dependencies]
 
   [dependencies.fabric]
     name = "fabric"
-    version = "0.91.6+1.20.2.mpkg.1"
+    version = "0.100.8+1.20.6.mpkg.1"
     versionName = ""
     type = "mod"
     ipfsHash = ""
-    Sha256 = "74dac56d85630429e5dbab71abd0fb69c8b1a771e7d1deb405e897fccbe45f5e"
-    url = "https://api.preview.minepkg.io/v1/releases/fabric/fabric@0.91.6+1.20.2.mpkg.1/download"
+    Sha256 = "aa0457cd765d62072c8ceeb75f4d8ea36698ae996e71c28a898da4d0a81752b2"
+    url = "https://api.preview.minepkg.io/v1/releases/fabric/fabric@0.100.8+1.20.6.mpkg.1/download"
     provider = "minepkg"
     dependent = ""
 

--- a/.minepkg-lock.toml
+++ b/.minepkg-lock.toml
@@ -4,20 +4,20 @@
 lockfileVersion = 1
 
 [fabric]
-  minecraft = "1.20.4"
+  minecraft = "1.20.2"
   fabricLoader = "0.16.10"
-  mapping = "1.20.4+build.3"
+  mapping = "1.20.2+build.4"
 
 [dependencies]
 
   [dependencies.fabric]
     name = "fabric"
-    version = "0.97.2+1.20.4.mpkg.1"
+    version = "0.91.6+1.20.2.mpkg.1"
     versionName = ""
     type = "mod"
     ipfsHash = ""
-    Sha256 = "3e820841b9f5d3d898bcb0f0abb9bfc15fb608bf07c74292ea3dd1b98d36460a"
-    url = "https://api.preview.minepkg.io/v1/releases/fabric/fabric@0.97.2+1.20.4.mpkg.1/download"
+    Sha256 = "74dac56d85630429e5dbab71abd0fb69c8b1a771e7d1deb405e897fccbe45f5e"
+    url = "https://api.preview.minepkg.io/v1/releases/fabric/fabric@0.91.6+1.20.2.mpkg.1/download"
     provider = "minepkg"
     dependent = ""
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
+minecraft_version=1.20.5
+yarn_mappings=1.20.5+build.1
 loader_version=0.16.10
 
 # Mod Properties
@@ -13,8 +13,8 @@ maven_group=io.minepkg
 archives_base_name=test-utils
 
 # Dependencies
-fabric_version=0.91.6+1.20.2
+fabric_version=0.97.8+1.20.5
 libgui_version=9.2.2+1.20.2
 
-minecraft_version_range= >=1.20.2 <=1.20.4
+minecraft_version_range= ~1.20.5
 java_version=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.3
 loader_version=0.16.10
 
 # Mod Properties
@@ -13,8 +13,8 @@ maven_group=io.minepkg
 archives_base_name=test-utils
 
 # Dependencies
-fabric_version=0.97.8+1.20.5
-libgui_version=9.2.2+1.20.2
+fabric_version=0.100.8+1.20.6
+libgui_version=10.0.0+1.20.6
 
-minecraft_version_range= ~1.20.5
-java_version=17
+minecraft_version_range= 1.20.6
+java_version=21

--- a/minepkg.toml
+++ b/minepkg.toml
@@ -13,7 +13,7 @@ manifestVersion = 0
 
 # These are global requirements
 [requirements]
-  minecraft = "~1.20.5"
+  minecraft = "1.20.6"
   fabricLoader = "*"
 
 [dependencies]

--- a/minepkg.toml
+++ b/minepkg.toml
@@ -13,7 +13,7 @@ manifestVersion = 0
 
 # These are global requirements
 [requirements]
-  minecraft = ">=1.20.2 <=1.20.4"
+  minecraft = "~1.20.5"
   fabricLoader = "*"
 
 [dependencies]

--- a/src/main/java/io/minepkg/testutils/RuleBookGUI.java
+++ b/src/main/java/io/minepkg/testutils/RuleBookGUI.java
@@ -8,11 +8,15 @@ import io.github.cottonmc.cotton.gui.widget.data.Axis;
 import io.github.cottonmc.cotton.gui.widget.data.Color.RGB;
 import io.github.cottonmc.cotton.gui.widget.data.HorizontalAlignment;
 import io.github.cottonmc.cotton.gui.widget.data.Insets;
-import io.minepkg.testutils.gui.*;
-import io.netty.buffer.Unpooled;
+import io.minepkg.testutils.gui.WClickableLabel;
+import io.minepkg.testutils.gui.WGradient;
+import io.minepkg.testutils.gui.WSpriteButton;
+import io.minepkg.testutils.gui.WUsableClippedPanel;
+import io.minepkg.testutils.network.c2s.SetRulePayload;
+import io.minepkg.testutils.network.c2s.SetTimePayload;
+import io.minepkg.testutils.network.c2s.SetWeatherPayload;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -221,10 +225,8 @@ public class RuleBookGUI extends LightweightGuiDescription {
 
   private void setTime(long timeOfDay) {
     preventTickUpdates = 1000;
-    PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
-    passedData.writeLong(timeOfDay);
     // Send packet to server to change the time
-    ClientPlayNetworking.send(TestUtils.SET_TIME_C2S, passedData);
+    ClientPlayNetworking.send(new SetTimePayload(timeOfDay));
     timeSlider.setValue((int)timeOfDay, false);
     envBox.setTimeOfDay(timeOfDay);
     // TODO: wait for response instead
@@ -233,20 +235,14 @@ public class RuleBookGUI extends LightweightGuiDescription {
 
   private void setRule(short id, boolean value) {
     preventTickUpdates += 1;
-    PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
-    // eg. 0 is day cycle
-    passedData.writeShort(id);
-    // enabling the button locks the weather
-    passedData.writeBoolean(value);
-    ClientPlayNetworking.send(TestUtils.SET_RULE_C2S, passedData);
+    // e.g. id 0 is day cycle, enabling the button locks the weather
+    ClientPlayNetworking.send(new SetRulePayload(id, value));
     preventTickUpdates = 20;
   }
 
   private void setWeather(short weather) {
     preventTickUpdates += 1;
-    PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
-    passedData.writeShort(weather);
-    ClientPlayNetworking.send(TestUtils.SET_WEATHER_C2S, passedData);
+    ClientPlayNetworking.send(new SetWeatherPayload(weather));
     preventTickUpdates = 30;
   }
 }

--- a/src/main/java/io/minepkg/testutils/TestUtils.java
+++ b/src/main/java/io/minepkg/testutils/TestUtils.java
@@ -1,16 +1,19 @@
 package io.minepkg.testutils;
 
-import io.netty.buffer.Unpooled;
+import io.minepkg.testutils.network.c2s.SetRulePayload;
+import io.minepkg.testutils.network.c2s.SetTimePayload;
+import io.minepkg.testutils.network.c2s.SetWeatherPayload;
+import io.minepkg.testutils.network.s2c.OpenBookPayload;
+import io.minepkg.testutils.network.s2c.WeatherGameruleSyncPayload;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroups;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
-
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -23,13 +26,6 @@ import org.apache.logging.log4j.Logger;
 public class TestUtils implements ModInitializer {
   public static final String MOD_ID = "testutils"; // Note: currently different from fabric.mod.json id
   public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
-
-  public static final Identifier OPEN_BOOK_S2C = TestUtils.id("open_book");
-  public static final Identifier WEATHER_GAMERULE_SYNC_S2C = TestUtils.id("weather_sync");
-
-  public static final Identifier SET_TIME_C2S = TestUtils.id("set_time");
-  public static final Identifier SET_RULE_C2S = TestUtils.id("set_rule");
-  public static final Identifier SET_WEATHER_C2S = TestUtils.id("set_weather");
 
   public static final short DO_DAYLIGHT_CYCLE_RULE = 1;
   public static final short DO_WEATHER_CYCLE_RULE = 2;
@@ -62,26 +58,24 @@ public class TestUtils implements ModInitializer {
     });
 
     // client wants to set the time
-    ServerPlayNetworking.registerGlobalReceiver(SET_TIME_C2S, (server, player, handler, buf, responseSender) -> {
-      // make sure its not over 24000
-      long wantedTime = buf.getLong(0) % 24000;
-
+    PayloadTypeRegistry.playC2S().register(SetTimePayload.ID, SetTimePayload.CODEC);
+    ServerPlayNetworking.registerGlobalReceiver(SetTimePayload.ID, (payload, context) -> {
       // Execute on the main thread
-      server.execute(() -> {
-        ServerWorld world = player.getServerWorld();
+      context.player().server.execute(() -> {
+        ServerWorld world = context.player().getServerWorld();
         // set the time
-        world.setTimeOfDay(wantedTime);
+        world.setTimeOfDay(payload.time());
       });
     });
 
     // client wants to set the weather
-    ServerPlayNetworking.registerGlobalReceiver(SET_WEATHER_C2S, (server, player, handler, buf, responseSender) -> {
-      short weather = buf.getShort(0);
-      ServerWorld world = player.getServerWorld();
+    PayloadTypeRegistry.playC2S().register(SetWeatherPayload.ID, SetWeatherPayload.CODEC);
+    ServerPlayNetworking.registerGlobalReceiver(SetWeatherPayload.ID, (payload, context) -> {
+      ServerWorld world = context.player().getServerWorld();
 
       // Execute on the main thread
-      server.execute(() -> {
-        switch (weather) {
+      context.player().server.execute(() -> {
+        switch (payload.weather()) {
           case WEATHER_CLEAR   -> world.setWeather(120000, 0, false, false);
           case WEATHER_RAIN    -> world.setWeather(0, 24000, true, false);
           case WEATHER_THUNDER -> world.setWeather(0, 24000, true, true);
@@ -89,10 +83,11 @@ public class TestUtils implements ModInitializer {
       });
     });
 
-    // client wants to set a rule (eg. freeze the time)
-    ServerPlayNetworking.registerGlobalReceiver(SET_RULE_C2S, (server, player, handler, buf, sender) -> {
-      short ruleID = buf.getShort(0);
-      boolean value = buf.getBoolean(2);
+    // client wants to set a rule (e.g. freeze the time)
+    PayloadTypeRegistry.playC2S().register(SetRulePayload.ID, SetRulePayload.CODEC);
+    ServerPlayNetworking.registerGlobalReceiver(SetRulePayload.ID, (payload, context) -> {
+      ServerPlayerEntity player = context.player();
+      MinecraftServer server = player.server;
       ServerWorld world = player.getServerWorld();
 
       // Execute on the main thread
@@ -100,22 +95,22 @@ public class TestUtils implements ModInitializer {
 
         GameRules rules = world.getGameRules();
 
-        switch(ruleID) {
+        switch(payload.ruleID()) {
           // daylight cycle
           case DO_DAYLIGHT_CYCLE_RULE -> {
             BooleanRule rule = rules.get(GameRules.DO_DAYLIGHT_CYCLE);
-            rule.set(value, world.getServer());
+            rule.set(payload.value(), server);
           }
           case DO_WEATHER_CYCLE_RULE -> {
             BooleanRule rule = rules.get(GameRules.DO_WEATHER_CYCLE);
-            rule.set(value, world.getServer());
-            broadcastWeatherRuleChange(server, value);
+            rule.set(payload.value(), server);
+            broadcastWeatherRuleChange(server, payload.value());
           }
           default ->
             LOGGER.error(
               "Player {} requested to change an unsupported rule id ({}). (client might be outdated)",
               player.getName().getString(),
-              ruleID
+              payload.ruleID()
             );
         }
       });
@@ -123,25 +118,22 @@ public class TestUtils implements ModInitializer {
   }
 
   public static void sendOpenBookPacket(ServerPlayerEntity player) {
-    PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
-    ServerPlayNetworking.send(player, OPEN_BOOK_S2C, packet);
+    ServerPlayNetworking.send(player, new OpenBookPayload());
   }
 
   public static void broadcastWeatherRuleChange(MinecraftServer server, boolean value) {
-    PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
-    packet.writeBoolean(value);
+    var payload = new WeatherGameruleSyncPayload(value);
 
     // Notify each player on the server about the weather gamerule update.
     server.getPlayerManager().getPlayerList().forEach(player -> {
-      ServerPlayNetworking.send(player, WEATHER_GAMERULE_SYNC_S2C, packet);
+      ServerPlayNetworking.send(player, payload);
     });
   }
 
   public static void sendWeatherRule(ServerPlayerEntity player) {
     ServerWorld world = player.getServerWorld();
     boolean doWeatherCycle = world.getGameRules().getBoolean(GameRules.DO_WEATHER_CYCLE);
-    PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
-    packet.writeBoolean(doWeatherCycle);
-    ServerPlayNetworking.send(player, WEATHER_GAMERULE_SYNC_S2C, packet);
+    var payload = new WeatherGameruleSyncPayload(doWeatherCycle);
+    ServerPlayNetworking.send(player, payload);
   }
 }

--- a/src/main/java/io/minepkg/testutils/gui/WGradient.java
+++ b/src/main/java/io/minepkg/testutils/gui/WGradient.java
@@ -5,7 +5,7 @@ import io.github.cottonmc.cotton.gui.widget.WWidget;
 import io.github.cottonmc.cotton.gui.widget.data.Color.RGB;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.gui.DrawContext; // Import DrawContext!
+import net.minecraft.client.gui.DrawContext;
 
 public class WGradient extends WWidget {
 

--- a/src/main/java/io/minepkg/testutils/network/c2s/SetRulePayload.java
+++ b/src/main/java/io/minepkg/testutils/network/c2s/SetRulePayload.java
@@ -1,0 +1,27 @@
+package io.minepkg.testutils.network.c2s;
+
+import io.minepkg.testutils.TestUtils;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record SetRulePayload(short ruleID, boolean value) implements CustomPayload {
+  public static final Id<SetRulePayload> ID = new Id<>(TestUtils.id("set_rule"));
+
+  public static final PacketCodec<PacketByteBuf, SetRulePayload> CODEC = PacketCodec.of(
+    (payload, buf) -> {
+      buf.writeShort(payload.ruleID);
+      buf.writeBoolean(payload.value);
+    },
+    buf -> {
+      short ruleID = buf.readShort();
+      boolean value = buf.readBoolean();
+      return new SetRulePayload(ruleID, value);
+    }
+  );
+
+  @Override
+  public Id<? extends CustomPayload> getId() {
+    return ID;
+  }
+}

--- a/src/main/java/io/minepkg/testutils/network/c2s/SetTimePayload.java
+++ b/src/main/java/io/minepkg/testutils/network/c2s/SetTimePayload.java
@@ -1,0 +1,27 @@
+package io.minepkg.testutils.network.c2s;
+
+import io.minepkg.testutils.TestUtils;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record SetTimePayload(long time) implements CustomPayload {
+  public static final Id<SetTimePayload> ID = new CustomPayload.Id<>(TestUtils.id("set_time"));
+
+  public static final PacketCodec<PacketByteBuf, SetTimePayload> CODEC = PacketCodec.of(
+    (payload, buf) -> {
+      buf.writeLong(payload.time);
+    },
+    buf -> {
+      // make sure it's not over 24000
+      long wantedTime = buf.readLong() % 24000;
+
+      return new SetTimePayload(wantedTime);
+    }
+  );
+
+  @Override
+  public Id<? extends CustomPayload> getId() {
+    return ID;
+  }
+}

--- a/src/main/java/io/minepkg/testutils/network/c2s/SetWeatherPayload.java
+++ b/src/main/java/io/minepkg/testutils/network/c2s/SetWeatherPayload.java
@@ -1,0 +1,20 @@
+package io.minepkg.testutils.network.c2s;
+
+import io.minepkg.testutils.TestUtils;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record SetWeatherPayload(short weather) implements CustomPayload {
+  public static final Id<SetWeatherPayload> ID = new Id<>(TestUtils.id("set_weather"));
+
+  public static final PacketCodec<PacketByteBuf, SetWeatherPayload> CODEC = PacketCodec.of(
+    (payload, buf) -> buf.writeShort(payload.weather),
+    buf -> new SetWeatherPayload(buf.readShort())
+  );
+
+  @Override
+  public Id<? extends CustomPayload> getId() {
+    return ID;
+  }
+}

--- a/src/main/java/io/minepkg/testutils/network/s2c/OpenBookPayload.java
+++ b/src/main/java/io/minepkg/testutils/network/s2c/OpenBookPayload.java
@@ -1,0 +1,20 @@
+package io.minepkg.testutils.network.s2c;
+
+import io.minepkg.testutils.TestUtils;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public class OpenBookPayload implements CustomPayload {
+  public static final Id<OpenBookPayload> ID = new CustomPayload.Id<>(TestUtils.id("open_book"));
+
+  public static final PacketCodec<PacketByteBuf, OpenBookPayload> CODEC = PacketCodec.of(
+    (payload, buf) -> {},
+    buf -> new OpenBookPayload()
+  );
+
+  @Override
+  public Id<? extends CustomPayload> getId() {
+    return ID;
+  }
+}

--- a/src/main/java/io/minepkg/testutils/network/s2c/WeatherGameruleSyncPayload.java
+++ b/src/main/java/io/minepkg/testutils/network/s2c/WeatherGameruleSyncPayload.java
@@ -1,0 +1,20 @@
+package io.minepkg.testutils.network.s2c;
+
+import io.minepkg.testutils.TestUtils;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+
+public record WeatherGameruleSyncPayload(boolean doWeatherCycle) implements CustomPayload {
+  public static final Id<WeatherGameruleSyncPayload> ID = new Id<>(TestUtils.id("weather_sync"));
+
+  public static final PacketCodec<PacketByteBuf, WeatherGameruleSyncPayload> CODEC = PacketCodec.of(
+    (payload, buf) -> buf.writeBoolean(payload.doWeatherCycle),
+    buf -> new WeatherGameruleSyncPayload(buf.readBoolean())
+  );
+
+  @Override
+  public Id<? extends CustomPayload> getId() {
+    return ID;
+  }
+}


### PR DESCRIPTION
3 Files are broken in 1.20.5:

- RuleBookGUI.java
- TestUtils.java
- TestUtilsClient.java

For example `ClientPlayNetworking.send(TestUtils.SET_TIME_C2S, passedData);` doesn't work anymore because

```
The method send(CustomPayload) in the type ClientPlayNetworking is not applicable for the arguments (Identifier, PacketByteBuf)Java(67108979)
void net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking.send(CustomPayload payload)
```


If you have time to fix it @Fourmisain :sweat_smile: But don't feel obliged